### PR TITLE
feature/ accessToken 만료 1분 전 재발급 로직 추가 및 로그인 간격 확인용 타이머 UI 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@vercel/postgres": "^0.7.2",
     "bcrypt": "^5.1.1",
     "embla-carousel-autoplay": "^8.0.0-rc17",
     "embla-carousel-react": "^8.0.0-rc17",

--- a/src/app/api/auth/access/route.ts
+++ b/src/app/api/auth/access/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createToken, tokenVerify } from '@/utils/auth'
+import { createToken, tokenExpCalculator, tokenVerify } from '@/utils/auth'
 
 export async function POST(req: NextRequest) {
   try {
@@ -18,8 +18,12 @@ export async function POST(req: NextRequest) {
 
     // 새 토큰 생성(refreshToken 검증 후 디코딩된 jwt 에서 반환받은 유저 정보를 바탕으로 accessToken을 생성한다.)
     const newAccessToken = createToken({ userEmail, userId }, true)
+
+    const exp = tokenExpCalculator(newAccessToken, true)
+
     return NextResponse.json({
       meg: '새로운 토큰이 발급되었습니다.',
+      exp,
       accessToken: newAccessToken,
       status: 201,
       success: true,

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import Joi from 'joi'
 import bycrypt from 'bcrypt'
 import { openDB } from '@/utils/connect'
-import { createToken } from '@/utils/auth'
+import { createToken, tokenExpCalculator } from '@/utils/auth'
 import { cookies } from 'next/headers'
 
 // POST | 로그인 요청 처리
@@ -75,7 +75,10 @@ export async function POST(req: NextRequest) {
     const accessToken = createToken({ userEmail, userId }, true)
     const refreshToken = createToken({ userEmail, userId }, false)
 
-    // 4. 리프레쉬 토큰 투키 저장
+
+     const exp = tokenExpCalculator(accessToken, true)
+
+    // 4. 리프레쉬 토큰 쿠키 저장
     cookies().set({
       name: 'refreshToken', // 쿠키 이름
       value: 'Bearer ' + refreshToken, // 쿠키에 저장할 값
@@ -84,12 +87,15 @@ export async function POST(req: NextRequest) {
       path: '/', // 쿠키에 접근할 수 있는 사이트 경로
     })
 
+    
+
     return NextResponse.json({
       success: true,
       meg: '정상적으로 처리 되었습니다..',
       status: 201,
       email: userEmail,
       profile: { image: profile_image, nickname: nickname || '익명의 명인' },
+      exp,
       accessToken,
     })
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css'
 import Header from '@/components/layout/Header'
 import ScrollAndNavButtons from '@/components/UI/common/ScrollAndNavButtons'
 import { Toaster } from 'react-hot-toast'
+import Timer from '@/components/UI/common/Timer'
 
 const gowunDodum = Gowun_Dodum({ weight: '400', subsets: ['latin'] })
 
@@ -36,6 +37,7 @@ export default function RootLayout({
     <html lang="ko" className=" h-full bg-[#162557]">
       <body className={`${gowunDodum.className}`}>
         <Header />
+        <Timer/>
         <main className="min-h-[100vh] w-full mx-auto max-w-[1700px] relative">
           <Toaster />
           {children}

--- a/src/components/UI/auth/login/LoginForm.tsx
+++ b/src/components/UI/auth/login/LoginForm.tsx
@@ -23,15 +23,13 @@ export default function LoginForm() {
 
   // 토큰 존재 시 리디렉트
   useEffect(() => {
-    if (hasToken) {
-      redirect('/')
-    }
+    if (hasToken) { redirect('/') }
   }, [router, hasToken])
 
   // 드래그어블 적용
   useDraggable(loginFormRef, 'free')
 
-  async function login(form: FormData) {
+  async function loginAction(form: FormData) {
     setIsLoading(true)
     const email = form.get('email')?.valueOf().toString() || ''
     const password = form.get('password')?.valueOf().toString() || ''
@@ -39,25 +37,21 @@ export default function LoginForm() {
     reqLogin({ email, password }).then(() => setIsLoading(false))
   }
 
-  function onClickBackMove() {
-    router.back()
-  }
+  function onClickBackMove() { router.back() }
 
   return (
-    <>
-      <form
-        ref={loginFormRef}
-        action={login}
-        className="shadow-[inset_0_0_0_2px_white]  rounded-[5px] flex flex-col fixed max-w-[470px] min-h-[350px] left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%] w-[100%] bg-transparent p-[5px]" 
-      >
-        <FormTitle>로그인</FormTitle>
-        <BackButton onClickBack={onClickBackMove} />
-        <LoginEmailInput />
-        <LoginPasswordInput />
-        <ForgotLink />
-        <ReqLoginInput isLoading={isLoading} />
-        <SignInGuideLink />
-      </form>
-    </>
+    <form
+      ref={loginFormRef}
+      action={loginAction}
+      className="shadow-[inset_0_0_0_2px_white]  rounded-[5px] flex flex-col fixed max-w-[470px] min-h-[350px] left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%] w-[100%] bg-transparent p-[5px]"
+    >
+      <FormTitle>로그인</FormTitle>
+      <BackButton onClickBack={onClickBackMove} />
+      <LoginEmailInput />
+      <LoginPasswordInput />
+      <ForgotLink />
+      <ReqLoginInput isLoading={isLoading} />
+      <SignInGuideLink />
+    </form>
   )
 }

--- a/src/components/UI/common/Timer.tsx
+++ b/src/components/UI/common/Timer.tsx
@@ -11,14 +11,14 @@ export default function Timer() {
 
     const [timeScale, setTimeScale] = useState(100)
     const checkTokenExp = useCallback(async () => {
-        
+
         const exp = getLoginExp()
 
         if (typeof exp !== 'number') return
         const currentTime = Math.floor(Date.now() / 1000)
-        const timeScale = Math.floor((exp - currentTime) / 900 * 100).toFixed(0)
-
-        setTimeScale(Number(timeScale))
+        const expired60SecondsAgo = currentTime - MINUTE_TO_SEC
+        const scale = ((exp - (expired60SecondsAgo))/90*100).toFixed(0)
+        setTimeScale(Number(scale))
 
         if (exp <= currentTime - MINUTE_TO_SEC) {
             const isSuccess = await requestNewAccessToken();
@@ -37,7 +37,7 @@ export default function Timer() {
     return (
 
         <article className="fixed right-[2em] top-[3em] text-white bg-[#00000039] rounded-[10px] p-[8px] font-sans text-[0.95em] ">
-            <p>자동 로그인 간격</p>
+            <p>재 로그인 까지</p>
 
             <h2 className="flex items-center justify-center"><HiClock /> <span className="mx-[5px]">{timeScale}</span></h2>
         </article>

--- a/src/components/UI/common/Timer.tsx
+++ b/src/components/UI/common/Timer.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { requestNewAccessToken } from "@/services/user/post"
+import { getLoginExp } from "@/utils/session-storage"
+import { useCallback, useEffect, useState } from "react"
+import { HiClock } from "react-icons/hi2"
+
+
+const MINUTE_TO_SEC = 60
+export default function Timer() {
+
+    const [timeScale, setTimeScale] = useState(100)
+    const checkTokenExp = useCallback(async () => {
+        
+        const exp = getLoginExp()
+
+        if (typeof exp !== 'number') return
+        const currentTime = Math.floor(Date.now() / 1000)
+        const timeScale = Math.floor((exp - currentTime) / 900 * 100).toFixed(0)
+
+        setTimeScale(Number(timeScale))
+
+        if (exp <= currentTime - MINUTE_TO_SEC) {
+            const isSuccess = await requestNewAccessToken();
+            if (isSuccess) {
+                checkTokenExp()
+                console.log("재발급 성공")
+            }
+        }
+    }, [])
+
+    useEffect(() => {
+        const timeId = setInterval(checkTokenExp, 1000)
+
+        return () => { clearTimeout(timeId) }
+    }, [checkTokenExp])
+    return (
+
+        <article className="fixed right-[2em] top-[3em] text-white bg-[#00000039] rounded-[10px] p-[8px] font-sans text-[0.95em] ">
+            <p>자동 로그인 간격</p>
+
+            <h2 className="flex items-center justify-center"><HiClock /> <span className="mx-[5px]">{timeScale}</span></h2>
+        </article>
+    )
+}

--- a/src/services/user/post.ts
+++ b/src/services/user/post.ts
@@ -3,6 +3,7 @@ import { defaultFetch } from '@/utils/fetcher'
 import {
   getAccessToken,
   setAccessToken,
+  setLoginExp,
   setUserInfo,
 } from '@/utils/session-storage'
 import { redirect } from 'next/navigation'
@@ -42,11 +43,17 @@ export const requestNewAccessToken = async () => {
 
   try {
     const respone = await fetch('/api/auth/access', config)
-    const { status, accessToken } = await respone.json()
+    const { status, accessToken,exp, success } = await respone.json()
 
-    if (status === 201) setAccessToken(accessToken)
+    if (status === 201) {
+      
+      setAccessToken(accessToken); setLoginExp(exp)
+      return success
+    
+    }
   } catch (error) {
     console.error('accessToken 발급 실패: ', error)
+    return false
   }
 }
 
@@ -67,7 +74,7 @@ export const reqLogin = async ({ ...userInfo }: UserType) => {
 
   const url = '/api/auth/login'
   const config = defaultConfig(Method.POST, user)
-  const { meg, success, accessToken, email, profile } = await defaultFetch(
+  const { meg, success, accessToken,exp, email, profile } = await defaultFetch(
     url,
     config,
   )
@@ -75,6 +82,11 @@ export const reqLogin = async ({ ...userInfo }: UserType) => {
   if (success) {
     setUserInfo({ profile, dbEmail: email })
     setAccessToken(accessToken)
+    setLoginExp(exp)
+
+
+
+    
     toast.success(`${email}님 환영합니다!. 잠시 후 Home 화면으로 이동합니다.`)
     setTimeout(() => {
       window.location.reload()

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -26,7 +26,7 @@ export const createToken = (
   const token = jwt.sign(
     {
       exp: isAccessToken
-        ? Math.floor(Date.now() / 1000) + 60 * 15
+        ? Math.floor(Date.now() / 1000) + 60 * 0.5
         : Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30, // 1달 = 30일
       data: payload,
     },

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -26,7 +26,7 @@ export const createToken = (
   const token = jwt.sign(
     {
       exp: isAccessToken
-        ? Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30
+        ? Math.floor(Date.now() / 1000) + 60 * 15
         : Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30, // 1달 = 30일
       data: payload,
     },
@@ -77,3 +77,20 @@ export const tokenVerify = (req: NextRequest, isAccessToken: boolean) => {
     }
   }
 }
+
+/**
+ * 토큰의 만료시간(exp) 추출
+ * @param token 토큰
+ * @param isAccessToken accessToken 여부(false 인 경우 refreshToken)
+ * @returns 
+ */
+export function tokenExpCalculator(token: string, isAccessToken: boolean) {
+
+  const decode = jwt.decode(token) as JwtPayload
+  if (!decode) return
+  const  exp  = decode.exp || 0
+
+  return exp
+}
+
+

--- a/src/utils/session-storage.ts
+++ b/src/utils/session-storage.ts
@@ -26,7 +26,7 @@ interface UserInfoType {
   }
 }
 /**
- * SessionStorage | 유저 정보를 로컬의 세션 스토로지에 저장한다.
+ * SET SessionStorage | 유저 정보 저장
  * @param user
  */
 export const setUserInfo = (user: UserInfoType) => {
@@ -34,19 +34,56 @@ export const setUserInfo = (user: UserInfoType) => {
 }
 
 /**
- * SessionStorage | 접근 토큰을 로컬의 세션 스토로지에 저장한다.
+ * GET SessionStorage | 유저 정보 가져오기
+ */
+export const getUserInfo = () => {
+  try {
+    sessionStorage.getItem('user')
+  } catch (error) {
+    console.error('user 정보 가져오기 실패:', error)
+  }
+}
+
+/**
+ * SET SessionStorage | 유저의 로그인 만료 시간 저장
+ * @param exp 
+ */
+export const setLoginExp = (exp: number) => {
+  sessionStorage.setItem('exp', JSON.stringify(exp))
+}
+
+/**
+ * GET essionStorage | 로그인 만료시간 가져오기
+ */
+export const getLoginExp = () => {
+  try {
+    const exp = sessionStorage.getItem('exp')
+    if(exp) {return Number(exp)}
+  } catch (error) {
+    console.error('exp 가져오기 실패:', error)
+    return false
+  }
+}
+
+/**
+ * SET SessionStorage | accessToken 저장
  * @param token accessToken
  */
+
 export const setAccessToken = (token: string) => {
   sessionStorage.setItem('token', token)
 }
 
+/**
+ * GET  SessionStorage | accessToken 가져오기
+ * @returns 
+ */
 export const getAccessToken = () => {
   try {
     const token = sessionStorage.getItem('token')
     return token
   } catch (error) {
-    console.error('sessionStorage.getItem 에러:' + error)
+    console.error('accessToken 가져오기 실패:' + error)
     return null
   }
 }


### PR DESCRIPTION
## 개요
- accessToken 이 만료되기 1분 전에 재발급할 수 있도록 로직을 추가함.
- 기존에는 북마크 리스트를 5초 마다 갱신하여 로그인 유무를 체크하였으나, 누가봐도 비효율적이고 잘못된 방식
- (프론트엔드)따라서 책임을 분리하여 accessToken 만을 처리하는 별도의 함수와 해당 함수가 적용될 Timer 컴포넌트를 추가함
- (프론트엔드)또한 사용자가 현재 로그인 상태의 갱신이 언제 이루어지는지 시각적으로 확인할 수 있도록 UI 를 추가 (해당 UI 의 활용 방식은 고민 중)
- (백엔드) 기존에는 exp 을 활용하지 않고 5초 마다 매번 GET 요청을 보내어 확인하는 방식이었으나, 토큰의 만료 시간인 exp 를 로그인 시 클라이언트 단으로 보내고, 해당 값을 재사용하는 방식으로 로직을 수정 하게 됨. 따라서 백엔드 코드에서도 exp 를 따로 추출하는 로직이 추가되었음.

## 기능 구현
[기능구현 과정](https://duklook.tistory.com/421#[%EA%B8%B0%EB%8A%A5-%EA%B5%AC%ED%98%84]-accesstoken-%EC%9E%AC%EB%B0%9C%EA%B8%89-%EA%B8%B0%EB%8A%A5-)

## 결과 이미지

![재발급](https://github.com/youngwan2/wise-saying/assets/107159871/6f35cf0a-fece-4a55-ab23-324d5fb5fa60)

- (c참고) 백분율 이므로 100 에서 0이 될 때 재발급 콘솔이 뜬다.
![시간측정](https://github.com/youngwan2/wise-saying/assets/107159871/a33a830d-dc83-4af4-a3b9-4ba78867a26b)
